### PR TITLE
Restart worker query implementation (sample)

### DIFF
--- a/src/lifecycle/handlers/mgmt.js
+++ b/src/lifecycle/handlers/mgmt.js
@@ -1,6 +1,7 @@
 import { UPool, UWorker } from '../../io/worker'
 import { keyring } from '../../utils/api'
 import { prb } from '../../message/proto.generated'
+import { addWorker } from '../lifecycle'
 import { returnAllWorkers } from './infra'
 
 const applyOwner = (item) => {
@@ -72,12 +73,32 @@ const requestUpdateWorker = async (message) => {
   return returnAllWorkers()
 }
 
+const requestRestartWorker = async (message) => {
+  const promises = [];
+
+  for (const item of message.content.requestRestartWorker.items) {
+    const idPb = prb.PoolOrWorkerQueryIdentity.fromObject(item.id)
+    const idKey = idPb.identity
+    const idValue = idPb[idKey]
+
+    const worker = await UWorker.getBy(idKey, idValue);
+    const context = globalThis.LIFECYCLE_CONTEXT;
+
+    promises.push(addWorker(worker, context));
+  }
+
+  await Promise.all(promises);
+
+  return returnAllWorkers()
+}
+
 export default {
   queryHandlers: {
     requestCreatePool,
     requestUpdatePool,
     requestCreateWorker,
     requestUpdateWorker,
+    requestRestartWorker,
   },
   plainHandlers: {},
 }

--- a/src/lifecycle/index.js
+++ b/src/lifecycle/index.js
@@ -36,6 +36,7 @@ const start = async () => {
     txQueue,
     _dispatchTx: txQueue.dispatch,
   }
+  globalThis.LIFECYCLE_CONTEXT = context;
 
   await setupRpc(context)
 

--- a/src/lifecycle/lifecycle.js
+++ b/src/lifecycle/lifecycle.js
@@ -37,7 +37,7 @@ const applyWorker = async (worker, context, result) => {
   }
 }
 
-const addWorker = async (worker, context) => {
+export const addWorker = async (worker, context) => {
   const ret = await createWorkerContext(worker, context)
   context.workerContexts.set(worker.uuid, ret)
 


### PR DESCRIPTION
It is just a sample - should not be merged like that.

Implemented restart worker query - so external tools could restart exactly selected workers - without restarting entire lifecycle component.